### PR TITLE
Add missing frac{1}{2} and intermediate step showing how the sum was …

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -364,7 +364,7 @@
   <p>
   For most step-sizes, the eigenvectors with largest eigenvalues converge the fastest. This triggers an explosion of progress in the first few iterations, before things slow down as the smaller eigenvectors' struggles are revealed. By writing the contributions of each eigenspace's error to the loss
   <dt-math block>
-  f(w^{k})-f(w^{\star})=\sum(1-\alpha\lambda_{i})^{2k}\lambda_{i}[x_{i}^{0}]^2
+  f(w^{k})-f(w^{\star})=\frac{1}{2}[x^k]^T\Lambda x^k=\frac{1}{2}\sum(1-\alpha\lambda_{i})^{2k}\lambda_{i}[x_{i}^{0}]^2
   </dt-math>
   we can visualize the contributions of each error component to the loss.
   </p>


### PR DESCRIPTION
That's how I derived that there is a missing \frac{1}{2}:

<img src="https://latex.codecogs.com/svg.latex?f(w)&space;-&space;f(w^\star)&space;=&space;\\&space;\frac{1}{2}&space;w^TAw&space;-&space;b^Tw&space;-&space;\frac{1}{2}&space;[w^\star]^TAw^\star&space;&plus;&space;b^Tw^\star)&space;=&space;\\&space;\frac{1}{2}&space;(w^TAw&space;-&space;2(Aw^\star)^Tw&space;-&space;[w^\star]^TAw^\star&space;&plus;&space;2(Aw^\star)^Tw^\star)&space;=&space;\\&space;\frac{1}{2}&space;(w^TAw&space;-&space;2(Aw^\star)^Tw&space;&plus;&space;[w^\star]^TAw^\star)&space;=&space;\\&space;\frac{1}{2}&space;(w^TAw&space;-&space;2[w^\star]^TAw&space;&plus;&space;[w^\star]^TAw^\star)&space;=&space;\\&space;\frac{1}{2}&space;(w^TA(w&space;-&space;w^\star)&space;-&space;[w^\star]^TA(w&space;-&space;w^\star))&space;=&space;\\&space;\frac{1}{2}&space;(w&space;-&space;w^\star)^TA(w&space;-&space;w^\star)&space;=&space;\\&space;\frac{1}{2}&space;(w&space;-&space;w^\star)^TQ\Lambda&space;Q^T(w&space;-&space;w^\star)&space;=&space;\\&space;\frac{1}{2}&space;x^T&space;\Lambda&space;x&space;=&space;\\&space;\frac{1}{2}&space;\sum_i^n&space;(1-\alpha\lambda_i)^2k\lambda_i[x_i^0]^2"/>