### PR TITLE
Fix missing vector transpose.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -830,7 +830,7 @@ instead. Note that this decay is dependent on the step-size.
   </dt-math>
 
   Following <dt-cite key="o2015adaptive"></dt-cite>, we go through the same motions, with the change of basis <dt-math>
-  x^{k} = Q(w^{k} - w^\star)</dt-math> and <dt-math> y^{k} = Qz^{k}</dt-math>, to yield the update rule
+  x^{k} = Q^T(w^{k} - w^\star)</dt-math> and <dt-math> y^{k} = Q^Tz^{k}</dt-math>, to yield the update rule
 
   <dt-math block>
   \begin{aligned}


### PR DESCRIPTION
Without transpose substitution does not yield expected equations:

<img src="https://latex.codecogs.com/svg.latex?\\&space;x^{k}&space;=&space;Q(w^{k}&space;-&space;w^\star)&space;\\&space;y^{k}&space;=&space;Qz^{k}\\&space;\\&space;y^{k&plus;1}&space;=&space;\beta&space;y^{k}&plus;\Lambda&space;x^{k}\\&space;x^{k&plus;1}&space;=&space;x^{k}-\alpha&space;y^{k&plus;1}\\&space;\\&space;Qz^{k&plus;1}&space;=&space;\beta&space;Qz^k&space;&plus;&space;\Lambda&space;Q(w^k&space;-&space;w^\star)\\&space;Q(w^{k&plus;1}&space;-&space;w^\star)&space;=&space;Q(w^k&space;-&space;w^\star)&space;-&space;\alpha&space;Qz^{k&plus;1})\\&space;\\&space;Q^{-1}Qz^{k&plus;1}&space;=&space;\beta&space;Q^{-1}Qz^k&space;&plus;&space;Q^{-1}\Lambda&space;Q(w^k&space;-&space;w^\star)\\&space;Q^{-1}Q(w^{k&plus;1}&space;-&space;w^\star)&space;=&space;Q^{-1}Q(w^k&space;-&space;w^\star)&space;-&space;\alpha&space;Q^{-1}Qz^{k&plus;1})\\&space;\\&space;z^{k&plus;1}&space;=&space;\beta&space;z^k&space;&plus;&space;Q^{-1}\Lambda&space;Q(w^k&space;-&space;w^\star)\\&space;(w^{k&plus;1}&space;-&space;w^\star)&space;=&space;(w^k&space;-&space;w^\star)&space;-&space;\alpha&space;z^{k&plus;1})\\&space;\\&space;z^{k&plus;1}&space;=&space;\beta&space;z^k&space;&plus;&space;Q^{-1}\Lambda&space;Q(w^k&space;-&space;A^{-1}b)\\&space;w^{k&plus;1}&space;=&space;w^k&space;-&space;\alpha&space;z^{k&plus;1}\\&space;\\"/>

But with transpose it does:

<img src="https://latex.codecogs.com/svg.latex?\\&space;x^{k}&space;=&space;Q^T(w^{k}&space;-&space;w^\star)&space;\\&space;y^{k}&space;=&space;Q^Tz^{k}\\&space;\\&space;y^{k&plus;1}&space;=&space;\beta&space;y^{k}&plus;\Lambda&space;x^{k}\\&space;x^{k&plus;1}&space;=&space;x^{k}-\alpha&space;y^{k&plus;1}\\&space;\\&space;Q^Tz^{k&plus;1}&space;=&space;\beta&space;Q^Tz^k&space;&plus;&space;\Lambda&space;Q^T(w^k&space;-&space;w^\star)\\&space;Q^T(w^{k&plus;1}&space;-&space;w^\star)&space;=&space;Q^T(w^k&space;-&space;w^\star)&space;-&space;\alpha&space;Q^Tz^{k&plus;1}\\&space;\\&space;QQ^Tz^{k&plus;1}&space;=&space;\beta&space;QQ^Tz^k&space;&plus;&space;Q\Lambda&space;Q^T(w^k&space;-&space;w^\star)\\&space;QQ^T(w^{k&plus;1}&space;-&space;w^\star)&space;=&space;QQ^T(w^k&space;-&space;w^\star)&space;-&space;\alpha&space;QQ^Tz^{k&plus;1}\\&space;\\&space;z^{k&plus;1}&space;=&space;\beta&space;z^k&space;&plus;&space;Q\Lambda&space;Q^T(w^k&space;-&space;w^\star)\\&space;(w^{k&plus;1}&space;-&space;w^\star)&space;=&space;(w^k&space;-&space;w^\star)&space;-&space;\alpha&space;z^{k&plus;1}\\&space;\\&space;z^{k&plus;1}&space;=&space;\beta&space;z^k&space;&plus;&space;A(w^k&space;-&space;A^{-1}b)\\&space;w^{k&plus;1}&space;=&space;w^k&space;-&space;\alpha&space;z^{k&plus;1}\\&space;\\&space;z^{k&plus;1}&space;=&space;\beta&space;z^k&space;&plus;&space;(Aw^k&space;-&space;b)\\&space;w^{k&plus;1}&space;=&space;w^k&space;-&space;\alpha&space;z^{k&plus;1}\\"/>

Transpose also make intuitive sense: `x` and `y` are error and velocity respectively in the eigenspace `Q`.